### PR TITLE
Limit the DEVELOPMENT_VERSION check to ORM project only

### DIFF
--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -18,11 +18,13 @@ if [ -z "$RELEASE_VERSION" ]; then
 else
 	echo "Setting version to '$RELEASE_VERSION'";
 fi
-if [ -z "$DEVELOPMENT_VERSION" ]; then
-	echo "ERROR: Development version argument not supplied"
-	exit 1
-else
-	echo "Setting development version to '$DEVELOPMENT_VERSION'";
+if [ "$PROJECT" == "orm" ]; then
+  if [ -z "$DEVELOPMENT_VERSION" ]; then
+    echo "ERROR: Development version argument not supplied"
+    exit 1
+  else
+    echo "Setting development version to '$DEVELOPMENT_VERSION'";
+  fi
 fi
 
 if [ -z "$BRANCH" ]; then


### PR DESCRIPTION
https://ci.hibernate.org/job/hibernate-validator-release/job/main/15/console

> echo 'ERROR: Development version argument not supplied'
ERROR: Development version argument not supplied

I see that the last time we released Search was just before the change https://github.com/marko-bekhta/hibernate-release-scripts/commit/258f8ea2640b694fbb984f3bb007819236f8cdbf 