### PR TITLE
Update reactive-check condition in prepare release script

### DIFF
--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -54,9 +54,8 @@ if [ "$PROJECT" == "orm" ]; then
 		-Pgradle.publish.key=$PLUGIN_PORTAL_USERNAME -Pgradle.publish.secret=$PLUGIN_PORTAL_PASSWORD \
 		-PhibernatePublishUsername=$OSSRH_USER -PhibernatePublishPassword=$OSSRH_PASSWORD \
 		-DsigningPassword=$RELEASE_GPG_PASSPHRASE -DsigningKeyFile=$RELEASE_GPG_PRIVATE_KEY_PATH
-elif [ "$PROJECT" == "reactive" ]; then
-	# Hibernate Reactive does these checks in the `cirelease` task (called by publish.sh)
-else
+elif [ "$PROJECT" != "reactive" ]; then
+  # Hibernate Reactive does these checks in the `cirelease` task (called by publish.sh)
 	"$SCRIPTS_DIR/check-sourceforge-availability.sh"
 	"$SCRIPTS_DIR/update-readme.sh" $PROJECT $RELEASE_VERSION "$WORKSPACE/README.md"
 	"$SCRIPTS_DIR/update-changelog.sh" $PROJECT $RELEASE_VERSION "$WORKSPACE/changelog.txt"


### PR DESCRIPTION
as right now we get:
```
Preparing the release ...

+ pushd /var/lib/jenkins/workspace/hibernate-search-release_7.1

/var/lib/jenkins/workspace/hibernate-search-release_7.1 /mnt/workdir/jenkins/workspace/hibernate-search-release_7.1

+ git config --local user.name 'Hibernate CI'

+ git config --local user.email ci@hibernate.org

/mnt/workdir/jenkins/workspace/hibernate-search-release_7.1/hibernate-release-scripts/prepare-release.sh: line 59: syntax error near unexpected token `else'

+ cleanup
```

so maybe let's just print a message.. or simply change to `elif [ "$PROJECT" != "reactive" ]; then` ?