### PR TITLE
Use maven.resolver.transport=wagon for infra releases

### DIFF
--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -59,7 +59,8 @@ elif [[ "$PROJECT" == "infra-theme" || "$PROJECT" == "infra-extensions" ]]; then
 				-Dtag=$RELEASE_VERSION \
 				-DreleaseVersion=$RELEASE_VERSION \
 				-DdevelopmentVersion=$DEVELOPMENT_VERSION \
-				-DperformRelease=true
+				-DperformRelease=true \
+				-Dmaven.resolver.transport=wagon
 elif [ "$PROJECT" != "reactive" ]; then
 	# Hibernate Reactive does these checks in the `cirelease` task (called by publish.sh)
 	"$SCRIPTS_DIR/check-sourceforge-availability.sh"

--- a/publish.sh
+++ b/publish.sh
@@ -100,7 +100,7 @@ elif [ "$PROJECT" == "reactive" ]; then
 	# Publish the artifact to OSSRH
 	exec_or_dry_run ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -PsontaypeOssrhUser=$OSSRH_USER -PsonatypeOssrgPassword=$OSSRH_PASSWORD
 elif [[ "$PROJECT" == "infra-theme" || "$PROJECT" == "infra-extensions" ]]; then
-  exec_or_dry_run ./mvnw release:perform -DperformRelease=true
+  exec_or_dry_run ./mvnw release:perform -DperformRelease=true -Dmaven.resolver.transport=wagon
 else
 	bash -xe "$SCRIPTS_DIR/deploy.sh" "$PROJECT"
 


### PR DESCRIPTION
> the default transport in Maven 3.9.0+ is NOT Wagon anymore

And I've found discussions and user reports that because of this change the release and deploy plugins may fail. 

So let's try this, but I guess.. I'll just revert all the infra-related changes to these scripts and adapt the projects to use the nexus plugin instead of the release one...