### PR TITLE
Don't use the build cache during releases

### DIFF
--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -48,7 +48,7 @@ if [ "$PROJECT" == "orm" ] || [ "$PROJECT" == "reactive" ]; then
 	# update changelog from JIRA
 	# tags the version
 	# changes the version to the provided development version
-	./gradlew clean releasePrepare -x test --no-scan --no-daemon \
+	./gradlew clean releasePrepare -x test --no-scan --no-daemon --no-build-cache \
 		-PreleaseVersion=$RELEASE_VERSION -PdevelopmentVersion=$DEVELOPMENT_VERSION -PgitRemote=origin -PgitBranch=$BRANCH -PdocPublishBranch="production" \
 		-PSONATYPE_OSSRH_USER=$OSSRH_USER -PSONATYPE_OSSRH_PASSWORD=$OSSRH_PASSWORD \
 		-Pgradle.publish.key=$PLUGIN_PORTAL_USERNAME -Pgradle.publish.secret=$PLUGIN_PORTAL_PASSWORD \

--- a/publish.sh
+++ b/publish.sh
@@ -77,7 +77,7 @@ RELEASE_VERSION_FAMILY=$(echo "$RELEASE_VERSION" | sed -E 's/^([0-9]+\.[0-9]+).*
 if [ "$PROJECT" == "orm" ] || [ "$PROJECT" == "reactive" ]; then
 	git config user.email ci@hibernate.org
 	git config user.name Hibernate-CI
-	exec_or_dry_run ./gradlew releasePerform closeAndReleaseSonatypeStagingRepository -x test --no-scan --no-daemon \
+	exec_or_dry_run ./gradlew releasePerform closeAndReleaseSonatypeStagingRepository -x test --no-scan --no-daemon --no-build-cache \
 		-PreleaseVersion=$RELEASE_VERSION -PdevelopmentVersion=$DEVELOPMENT_VERSION -PgitRemote=origin -PgitBranch=$BRANCH -PdocPublishBranch=production \
 		-PSONATYPE_OSSRH_USER=$OSSRH_USER -PSONATYPE_OSSRH_PASSWORD=$OSSRH_PASSWORD \
 		-Pgradle.publish.key=$PLUGIN_PORTAL_USERNAME -Pgradle.publish.secret=$PLUGIN_PORTAL_PASSWORD \


### PR DESCRIPTION
So that we're extra sure we're not relying on cache left by a previous Gradle execution.