### PR TITLE
Disable the build cache for all Maven projects 

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -27,16 +27,20 @@ else
 
 	if [ "$PROJECT" == "ogm" ]; then
 		ADDITIONAL_OPTIONS="-DmongodbProvider=external -DskipITs"
-	elif [ "$PROJECT" == "search" ] || [ "$PROJECT" == "validator" ]; then
-		# Disable Develocity build scan publication and build caching
-		ADDITIONAL_OPTIONS="-Dscan=false -Dno-build-cache -Dgradle.cache.remote.enabled=false -Dgradle.cache.local.enabled=false"
 	else
 		ADDITIONAL_OPTIONS=""
 	fi
 
 	source "$SCRIPTS_DIR/mvn-setup.sh"
 
-	./mvnw -Pdocbook,documentation-pdf,dist,perf,relocation,release clean deploy -DskipTests=true -Dcheckstyle.skip=true -DperformRelease=true -Dmaven.compiler.useIncrementalCompilation=false $ADDITIONAL_OPTIONS
+	./mvnw clean deploy \
+		-Pdocbook,documentation-pdf,dist,perf,relocation,release \
+		-DperformRelease=true \
+		-DskipTests=true -Dcheckstyle.skip=true \
+		-Dmaven.compiler.useIncrementalCompilation=false \
+		-Dscan=false -Dno-build-cache \
+		-Dgradle.cache.remote.enabled=false -Dgradle.cache.local.enabled=false \
+	 	$ADDITIONAL_OPTIONS
 fi
 
 popd

--- a/deploy.sh
+++ b/deploy.sh
@@ -38,8 +38,10 @@ else
 		-DperformRelease=true \
 		-DskipTests=true -Dcheckstyle.skip=true \
 		-Dmaven.compiler.useIncrementalCompilation=false \
+		-Ddevelocity.enabled=false \
 		-Dscan=false -Dno-build-cache \
 		-Dgradle.cache.remote.enabled=false -Dgradle.cache.local.enabled=false \
+		-Ddevelocity.cache.remote.enabled=false -Ddevelocity.cache.local.enabled=false \
 	 	$ADDITIONAL_OPTIONS
 fi
 


### PR DESCRIPTION
Technically this changes nothing right now, since only Search and
Validator use the build cache,
but it's an additional safety net in case new projects start using the
build cache.

Also, add even more options to disable Develocity features in releases.

"gradle.*" options are obsolete but shouldn't hurt, and might be useful
when releasing old branches.