### PR TITLE
Use env-vars for secrets used during release for ORM and HR (Gradle builds) rather than Project properties

### DIFF
--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -49,11 +49,8 @@ if [ "$PROJECT" == "orm" ] || [ "$PROJECT" == "reactive" ]; then
 	# tags the version
 	# changes the version to the provided development version
 	./gradlew clean releasePrepare -x test --no-scan --no-daemon --no-build-cache \
-		-PreleaseVersion=$RELEASE_VERSION -PdevelopmentVersion=$DEVELOPMENT_VERSION -PgitRemote=origin -PgitBranch=$BRANCH -PdocPublishBranch="production" \
-		-PSONATYPE_OSSRH_USER=$OSSRH_USER -PSONATYPE_OSSRH_PASSWORD=$OSSRH_PASSWORD \
-		-Pgradle.publish.key=$PLUGIN_PORTAL_USERNAME -Pgradle.publish.secret=$PLUGIN_PORTAL_PASSWORD \
-		-PhibernatePublishUsername=$OSSRH_USER -PhibernatePublishPassword=$OSSRH_PASSWORD \
-		-DsigningPassword=$RELEASE_GPG_PASSPHRASE -DsigningKeyFile=$RELEASE_GPG_PRIVATE_KEY_PATH
+		-PreleaseVersion=$RELEASE_VERSION -PdevelopmentVersion=$DEVELOPMENT_VERSION
+		-PgitRemote=origin
 else
 	if [[ "$PROJECT" != "tools" && "$PROJECT" != "hcann" && ! $PROJECT =~ ^infra-.+ ]]; then
 		# These projects do not have a distribution bundle archive,


### PR DESCRIPTION
Use env-vars for secrets used during release for ORM and HR (Gradle builds) rather than Project properties

NOTE : ready for review, but draft as we need to coordinate changes in ORM and HR projects