### PR TITLE
Pass the branch and dev version to prepare-release

### DIFF
--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -1,11 +1,32 @@
 #!/usr/bin/env -S bash -e
 
+# Default to a well-known CI environment variable
+BRANCH="$BRANCH_NAME"
+
+while getopts 'd:b:' opt; do
+  case "$opt" in
+  b)
+    BRANCH="$OPTARG"
+    ;;
+  d)
+    DEVELOPMENT_VERSION="$OPTARG"
+    ;;
+  \?)
+    usage
+    exit 1
+    ;;
+  esac
+done
+shift $((OPTIND - 1))
+
 SCRIPTS_DIR="$(readlink -f ${BASH_SOURCE[0]} | xargs dirname)"
 
 PROJECT=$1
 RELEASE_VERSION=$2
 INHERITED_VERSION=$3
-DEVELOPMENT_VERSION=$3
+if [ -n "$3" ]; then
+  DEVELOPMENT_VERSION=$3
+fi
 WORKSPACE=${WORKSPACE:-'.'}
 
 if [ -z "$PROJECT" ]; then

--- a/release.sh
+++ b/release.sh
@@ -194,7 +194,7 @@ if [ "$PUSH_CHANGES" != "true" ]; then
 	ADDITIONAL_OPTIONS="-d"
 fi
 
-bash -xe "$SCRIPTS_DIR/prepare-release.sh" "$PROJECT" "$RELEASE_VERSION"
+bash -xe "$SCRIPTS_DIR/prepare-release.sh" -b "$BRANCH" -d "$DEVELOPMENT_VERSION" "$PROJECT" "$RELEASE_VERSION"
 
 #bash -xe "$SCRIPTS_DIR/jira-release.sh" $ADDITIONAL_OPTIONS "$JIRA_PROJECT" "$RELEASE_VERSION_BASIS" "$NEXT_VERSION_BASIS"
 


### PR DESCRIPTION
as `-smth blabla` options to not break the current script logic... 
`prepare-release.sh` has 3/4 arguments, but setting it in the release script will make the maven version set fail...