### PR TITLE
Do not specify the maven help plugin version

### DIFF
--- a/determine-current-version.sh
+++ b/determine-current-version.sh
@@ -23,5 +23,5 @@ elif [ -f './gradlew' ]; then
 else
 	# Maven-based build
 
-	mvn -f $WORKSPACE/pom.xml org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version -q -DforceStdout
+	mvn -f $WORKSPACE/pom.xml org.apache.maven.plugins:maven-help-plugin:evaluate -Dexpression=project.version -q -DforceStdout
 fi


### PR DESCRIPTION
Running this on current projects results in no version being printed. 
Removing the plugin version let the maven pick one which seems to work:
```
mvn -f pom.xml org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version -q -DforceStdout
Running `hibernate-asciidoctor-theme/mvnw`...

mvn -f pom.xml org.apache.maven.plugins:maven-help-plugin:evaluate -Dexpression=project.version -q -DforceStdout 
Running `hibernate-asciidoctor-theme/mvnw`...
5.0.7-SNAPSHOT%                                                                     
```