### PR TITLE
Add a script to populate the array of available versions (per project)

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -202,6 +202,10 @@ if [ "$PROJECT" == "orm" ] || [ "$PROJECT" == "reactive" ] || [ "$PROJECT" == "m
 					--no-scan --no-daemon --no-build-cache --stacktrace $EXTRA_ARGS \
 					-PreleaseVersion=$RELEASE_VERSION -PdevelopmentVersion=$DEVELOPMENT_VERSION \
 					-PdocPublishBranch=production -PgitRemote=origin -PgitBranch=$BRANCH
+
+	if [ "$PROJECT" == "orm" ] || [ "$PROJECT" == "reactive" ]; then
+		exec_or_dry_run bash -xe "$SCRIPTS_DIR/update-available-versions-json.sh" "$PROJECT" "$RELEASE_VERSION_FAMILY"
+	fi
 else
 	EXTRA_ARGS=""
 	if [ "$USE_JRELEASER_RELEASE" == "true" ]; then
@@ -213,6 +217,7 @@ else
 	if [[ "$PROJECT" != "tools" && "$PROJECT" != "hcann" && ! $PROJECT =~ ^infra-.+ ]]; then
 		exec_or_dry_run bash -xe "$SCRIPTS_DIR/upload-distribution.sh" "$PROJECT" "$RELEASE_VERSION"
 		exec_or_dry_run bash -xe "$SCRIPTS_DIR/upload-documentation.sh" "$PROJECT" "$RELEASE_VERSION" "$RELEASE_VERSION_FAMILY"
+		exec_or_dry_run bash -xe "$SCRIPTS_DIR/update-available-versions-json.sh" "$PROJECT" "$RELEASE_VERSION_FAMILY"
 	fi
 
 	bash -xe "$SCRIPTS_DIR/update-version.sh" "$PROJECT" "$DEVELOPMENT_VERSION"

--- a/update-available-versions-json.sh
+++ b/update-available-versions-json.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env -S bash -e
+
+PROJECT=$1
+VERSION_FAMILY=$2
+WORKSPACE=${WORKSPACE:-'.'}
+
+if [ -z "$PROJECT" ]; then
+	echo "ERROR: Project not supplied"
+	exit 1
+fi
+if [ -z "$VERSION_FAMILY" ]; then
+	echo "ERROR: Version family argument not supplied"
+	exit 1
+fi
+
+pushd ${WORKSPACE}
+
+wget -q http://docs.jboss.org/hibernate/_available-versions/${PROJECT}.json -O "available-${PROJECT}.json"
+if [ ! -s ${PROJECT}.json ]; then
+  echo "Error downloading the ${PROJECT}.json descriptor. Exiting."
+  exit 1
+fi
+
+if jq -e "contains([\"$VERSION_FAMILY\"])" "available-${PROJECT}.json" >/dev/null; then
+  echo "Version '$VERSION_FAMILY' already exists."
+else
+  echo "Version '$VERSION_FAMILY' not found. Adding..."
+
+  if jq ". + [\"$VERSION_FAMILY\"]" "available-${PROJECT}.json" > "available-${PROJECT}-updated.json"; then
+    echo "Uploading updated file..."
+    rsync -z --progress "available-${PROJECT}-updated.json" "filemgmt-prod-sync.jboss.org:/docs_htdocs/hibernate/_available-versions/${PROJECT}.json"
+    rm -f "available-${PROJECT}-updated.json"
+  else
+    echo "Error: Failed to add available version '$VERSION_FAMILY'..."
+    exit 1
+  fi
+fi
+
+popd


### PR DESCRIPTION
a new JSON file `docs_htdocs/hibernate/_available-versions/${PROJECT}.json` that will simply have  an array of versions:
```json
[ "1.0", "2.0", "2.1",  "3.0" ...  ]
```

And then we can use that in the script to populate the dropdown in the docs...
I've tried to add it in a way that wouldn't require us to go and update project builds.
If this makes sense, I'll go create the files with the current versions and then update the js in orm (as a first step to share this between projects)