### PR TITLE
Update the project version in the gradle.properties if the `./gradle/version.properties` file is not available

### DIFF
--- a/update-version.sh
+++ b/update-version.sh
@@ -23,7 +23,13 @@ pushd $WORKSPACE
 
 if [ -f "./gradlew" ]; then
 	# Gradle-based build
-	echo "hibernateVersion=$NEW_VERSION" > ./gradle/version.properties
+	if [ -f "./gradle/version.properties" ]; then
+  	# ORM/Reactive custom version location:
+  	echo "hibernateVersion=$NEW_VERSION" > ./gradle/version.properties
+  else
+    # More standard location for other gradle-based projects:
+    sed -i "s/^version=.*$/version=$NEW_VERSION/g" gradle.properties
+  fi
 else
 	# Maven-based build
 	source "$SCRIPTS_DIR/mvn-setup.sh"


### PR DESCRIPTION
This may be helpful for projects other than ORM/Reactive.

* Related to https://github.com/hibernate/version-injection-plugin/pull/3