### PR TITLE
Add support for MD changelog files ( and add a migration script to convert our current txt files to md format)

### DIFF
--- a/misc/migrate-changelog.sh
+++ b/misc/migrate-changelog.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env -S bash -e
+
+########################################################################################################################
+# Migrates a changelog.txt (plain text format) to changelog.md (Markdown format).
+#
+# Usage: migrate-changelog.sh <changelog.txt> [<changelog.md>]
+#
+# If the output path is not specified, it defaults to changelog.md in the same directory.
+########################################################################################################################
+
+INPUT=$1
+OUTPUT=$2
+
+if [ -z "$INPUT" ]; then
+  echo "Usage: migrate-changelog.sh <changelog.txt> [<changelog.md>]"
+  exit 1
+fi
+if ! [ -f "$INPUT" ]; then
+  echo "ERROR: '$INPUT' is not a valid file"
+  exit 1
+fi
+
+if [ -z "$OUTPUT" ]; then
+  OUTPUT="$(dirname "$INPUT")/changelog.md"
+fi
+
+# Auto-detect the JIRA project key from the first issue reference in the file
+# Handles both "    * KEY-123" and "    * [KEY-123]" formats
+JIRA_KEY=$(grep -oP '^\s+\*\s+\[?\K[A-Z]+-' "$INPUT" | head -1 | sed 's/-$//')
+if [ -z "$JIRA_KEY" ]; then
+  echo "ERROR: Could not detect JIRA project key from issue entries in '$INPUT'"
+  exit 1
+fi
+echo "Detected JIRA project key: $JIRA_KEY"
+
+# Detect whether this is an ORM-style changelog (with "Changes in" prefix)
+IS_ORM_STYLE=false
+if grep -qP '^Changes in ' "$INPUT"; then
+  IS_ORM_STYLE=true
+fi
+
+{
+  echo "# Changelog"
+  echo ""
+
+  prev_line=""
+  first_line=true
+  skip_blanks=false
+
+  while IFS= read -r line; do
+    # Skip title underline (=== lines) and discard the buffered title line above it
+    if [[ "$line" =~ ^=+$ ]]; then
+      prev_line="__SKIP__"
+      skip_blanks=true
+      continue
+    fi
+
+    # Skip blank lines immediately following the title block
+    if [[ "$skip_blanks" == true ]]; then
+      if [[ -z "$line" ]]; then
+        continue
+      fi
+      skip_blanks=false
+    fi
+
+    # Skip separator lines (--- lines under version headers)
+    if [[ "$line" =~ ^-+$ ]]; then
+      continue
+    fi
+
+    if [[ "$first_line" == true ]]; then
+      first_line=false
+      prev_line="$line"
+      continue
+    fi
+
+    # Process the previously buffered line
+    process_line="$prev_line"
+    prev_line="$line"
+
+    # Skip if the previous line was discarded (title block)
+    if [[ "$process_line" == "__SKIP__" ]]; then
+      continue
+    fi
+
+    # Version header: ORM style "Changes in X.Y.Z (date)"
+    if [[ "$IS_ORM_STYLE" == true ]] && [[ "$process_line" =~ ^Changes\ in\ (.+) ]]; then
+      echo "## ${BASH_REMATCH[1]}"
+      continue
+    fi
+
+    # Version header line (non-ORM)
+    if [[ "$process_line" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]] && [[ "$process_line" =~ \( ]]; then
+      echo "## $process_line"
+      continue
+    fi
+
+    # JIRA version URL
+    if [[ "$process_line" =~ ^https://hibernate\.atlassian\.net/projects/.+/versions/ ]]; then
+      echo "[Full changelog]($process_line)"
+      continue
+    fi
+
+    # Issue type header: "** Type" → "### Type"
+    if [[ "$process_line" =~ ^\*\*\ (.+) ]]; then
+      echo "### ${BASH_REMATCH[1]}"
+      continue
+    fi
+
+    # Issue entry: "    * KEY-123 summary" → "* [KEY-123](browse-link) - summary"
+    if [[ "$process_line" =~ ^[[:space:]]+\*[[:space:]]+($JIRA_KEY-[0-9]+)[[:space:]]+(.*) ]]; then
+      local_key="${BASH_REMATCH[1]}"
+      local_summary="${BASH_REMATCH[2]}"
+      echo "* [${local_key}](https://hibernate.atlassian.net/browse/${local_key}) - $local_summary"
+      continue
+    fi
+
+    # Issue entry (older format with brackets): "    * [KEY-123] - summary"
+    if [[ "$process_line" =~ ^[[:space:]]+\*[[:space:]]+\[($JIRA_KEY-[0-9]+)\][[:space:]]*(.*) ]]; then
+      local_key="${BASH_REMATCH[1]}"
+      local_summary="${BASH_REMATCH[2]}"
+      echo "* [${local_key}](https://hibernate.atlassian.net/browse/${local_key}) ${local_summary}"
+      continue
+    fi
+
+    # Pass through everything else (blank lines, etc.)
+    echo "$process_line"
+  done < "$INPUT"
+
+  # Process the last buffered line
+  if [[ -n "$prev_line" ]] && [[ "$prev_line" != "__SKIP__" ]]; then
+    echo "$prev_line"
+  fi
+} > "$OUTPUT"
+
+echo "Migrated '$INPUT' -> '$OUTPUT'"
+echo ""
+echo "Next steps:"
+echo "  1. Review the generated $OUTPUT"
+echo "  2. Remove the old $INPUT"
+echo "  3. Commit both changes"

--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -78,7 +78,12 @@ if [ -f "$WORKSPACE/README.md" ]; then
   "$SCRIPTS_DIR/update-readme.sh" $PROJECT $RELEASE_VERSION "$WORKSPACE/README.md"
 fi
 if [ "$PROJECT" == "orm" ] || [ "$PROJECT" == "search" ] || [ "$PROJECT" == "validator" ]; then
-  "$SCRIPTS_DIR/update-changelog.sh" $PROJECT $RELEASE_VERSION "$WORKSPACE/changelog.txt"
+  if [ -f "$WORKSPACE/changelog.md" ]; then
+    CHANGELOG_FILE="$WORKSPACE/changelog.md"
+  else
+    CHANGELOG_FILE="$WORKSPACE/changelog.txt"
+  fi
+  "$SCRIPTS_DIR/update-changelog.sh" $PROJECT $RELEASE_VERSION "$CHANGELOG_FILE"
 fi
 "$SCRIPTS_DIR/validate-release.sh" $PROJECT $RELEASE_VERSION
 

--- a/update-changelog.sh
+++ b/update-changelog.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env -S bash -e
 
 ########################################################################################################################
-# The purpose of this tool is to update the changelog.txt using JIRA's REST API to get the required information
+# The purpose of this tool is to update the changelog using JIRA's REST API to get the required information.
+# Supports both plain text (changelog.txt) and Markdown (changelog.md) formats.
 ########################################################################################################################
 
 PROJECT=$1
@@ -97,20 +98,18 @@ function list_jira_issues() {
 }
 
 #######################################################################################################################
-# Creates the required update for changelog.txt. It creates the following:
+# Creates the required changelog update in plain text format:
 #
 # <version> (<date>)
 # -------------------------
 #
 # ** <issue-type-1>
-#    * PROJECT-<key> - <summary>
+#    * PROJECT-<key> <summary>
 #    ...
-#
 # ** <issue-type-2>
-#    * PROJECT-<key> - <summary>
+#    * PROJECT-<key> <summary>
 #    ...
-#
-function create_changelog_update() {
+function create_changelog_update_txt() {
   local ID=$1
   if [ "$PROJECT" == "orm" ]; then
     echo "Changes in $RELEASE_VERSION ($(date +'%B %d, %Y'))"
@@ -144,6 +143,59 @@ function create_changelog_update() {
   echo ""
 }
 
+#######################################################################################################################
+# Creates the required changelog update in Markdown format:
+#
+# ## <version> (<date>)
+#
+# [Full changelog](<jira-link>)
+#
+# ### <issue-type-1>
+# * [PROJECT-<key>](<browse-link>) - <summary>
+# ...
+#
+function create_changelog_update_md() {
+  local ID=$1
+  if [ "$PROJECT" == "orm" ]; then
+    echo "## $RELEASE_VERSION ($(date +'%B %d, %Y'))"
+  else
+    echo "## $RELEASE_VERSION ($(date +%Y-%m-%d))"
+  fi
+  echo ""
+  echo "[Full changelog](https://hibernate.atlassian.net/projects/${JIRA_KEY}/versions/$ID)"
+  echo ""
+  local previous_issuetype=""
+  while true; do
+    JSON_RESPONSE=$(list_jira_issues "" "${NEXT_PAGE_TOKEN}")
+    NEXT_PAGE_TOKEN=$(echo "${JSON_RESPONSE}" | jq -r '.nextPageToken //""')
+
+    echo $JSON_RESPONSE | jq -r '.issues[] | (.fields.issuetype.name + "\t" + .key + "\t" + .fields.summary)' |
+      while IFS=$'\t' read -r issuetype key summary; do
+        if [ "$previous_issuetype" != "$issuetype" ]; then
+          previous_issuetype="$issuetype"
+          echo ""
+          echo "### $issuetype"
+        fi
+        echo "* [${key}](https://hibernate.atlassian.net/browse/${key}) - $summary"
+      done
+    if [[ -z "${NEXT_PAGE_TOKEN}" ]]; then
+      break
+    fi
+  done
+
+  echo ""
+}
+
+#######################################################################################################################
+# Dispatches to the appropriate format based on the changelog file extension.
+function create_changelog_update() {
+  if [[ "$CHANGELOG" == *.md ]]; then
+    create_changelog_update_md "$@"
+  else
+    create_changelog_update_txt "$@"
+  fi
+}
+
 ########################################################################################################################
 # Putting it all together
 ########################################################################################################################
@@ -164,6 +216,17 @@ JIRA_VERSION_ID="$(echo $JIRA_VERSION | jq -r ".id")"
 changelog_update_file="$(mktemp)"
 trap "rm -f $changelog_update_file" EXIT
 create_changelog_update $JIRA_VERSION_ID > "$changelog_update_file"
-sed -i "3r$changelog_update_file" "$CHANGELOG"
+
+if [[ "$CHANGELOG" == *.md ]]; then
+  # For Markdown changelogs, insert after the title line (# Changelog) and blank line
+  INSERT_LINE=$(grep -n '^# ' "$CHANGELOG" | head -1 | cut -d: -f1)
+  if [ -n "$INSERT_LINE" ]; then
+    sed -i "$((INSERT_LINE + 1))r$changelog_update_file" "$CHANGELOG"
+  else
+    sed -i "1r$changelog_update_file" "$CHANGELOG"
+  fi
+else
+  sed -i "3r$changelog_update_file" "$CHANGELOG"
+fi
 git add "$CHANGELOG"
-git commit -m "[Jenkins release job] changelog.txt updated by release build ${RELEASE_VERSION}"
+git commit -m "[Jenkins release job] $(basename "$CHANGELOG") updated by release build ${RELEASE_VERSION}"

--- a/validate-release.sh
+++ b/validate-release.sh
@@ -3,7 +3,11 @@
 PROJECT=$1
 RELEASE_VERSION=$2
 WORKSPACE=${WORKSPACE:-'.'}
-CHANGELOG=$WORKSPACE/changelog.txt
+if [ -f "$WORKSPACE/changelog.md" ]; then
+  CHANGELOG=$WORKSPACE/changelog.md
+else
+  CHANGELOG=$WORKSPACE/changelog.txt
+fi
 README=$WORKSPACE/README.md
 
 pushd ${WORKSPACE}


### PR DESCRIPTION
I was looking at the dependabot PRs and the way it shows the changelog in a single line .. so I though let's give this a try and use md format that seems to be working better with dependabot ?
tried the script for "migration" on Search/Validator